### PR TITLE
Update composer.json to allow newer version of league/geotools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.4|^8.0",
         "illuminate/support": ">=5.1",
         "spatie/data-transfer-object": "2.8.3",
-        "league/geotools": "^0.8.3"
+        "league/geotools": ">=0.8.3"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",


### PR DESCRIPTION
Your package seems to work with newer versions of Laravel, but cannot install right now because `league/geotools:0.8.3` explicitly requires older versions of `symfony/console`. 

If you allow newer league/geotools, things seem to work fine and we can use this in newer Laravel.